### PR TITLE
Create new way to assign "pixels relative to breakpoint canvas size"

### DIFF
--- a/less/demo-la-shoes.less
+++ b/less/demo-la-shoes.less
@@ -53,8 +53,12 @@ html {
 	font-family: @font-family;
 	color:white;
 }
-h1, h2 {
+h1, h2, h3, h4, h5, h6 {
 	.heading-style();
+	margin: 0;
+}
+p {
+	margin:0;
 }
 .runner-1 {
 	img {
@@ -78,7 +82,6 @@ h1, h2 {
 
 	h1 {
 		position: absolute;
-		margin: 0;
 		top: -230*@p;
 		left: 40*@p;
 		color: @purple;
@@ -97,8 +100,7 @@ h1, h2 {
 	}
 	.copy {
 		p {
-			margin: 0;
-			padding: 0 0 28*@p;
+			padding-bottom: 28*@p;
 			font-size: 18*@p;
 			line-height: 28*@p;
 		}
@@ -154,7 +156,8 @@ h1, h2 {
 
 	.copy {
 		position: relative;
-		margin: -520*@p 0 0 130*@p;
+		margin-top: -520*@p;
+		margin-left: 130*@p;
 		width: 320*@p;
 		transform: translate(0, 210*@p);
 
@@ -168,8 +171,7 @@ h1, h2 {
 		}
 
 		p {
-			margin: 0;
-			padding: 0 0 26*@p;
+			padding-bottom: 26*@p;
 			font-size: 16*@p;
 			line-height: 26*@p;
 		}

--- a/less/demo-la-shoes.less
+++ b/less/demo-la-shoes.less
@@ -2,16 +2,6 @@
 
 
 
-// Design-time overrides
-// By overriding these variables, you can control when (or if) each media query kicks in.
-@xs: ~"(max-width:0px)";
-@sm: ~"(max-width:0px)";
-@md: ~"all";
-@lg: ~"(max-width:0px)";
-@xl: ~"(max-width:0px)";
-
-
-
 // Variables
 @purple: #7B2F9F;
 @pink: #C43374;
@@ -74,44 +64,44 @@ h1, h2 {
 .introduction {
 	position: relative;
 	z-index: 20;
-	width: 420rem;
-	margin: -675rem 0 0 auto;
-	padding: 10rem 75rem 160rem 45rem;
+	width: 420*@p;
+	margin: -675*@p 0 0 auto;
+	padding: 10*@p 75*@p 160*@p 45*@p;
 	background: @lt-pink;
 
 	&:before {
 		.pseudo-box-top();
-		border-top-width: 125rem;
-		border-right: 210rem solid @lt-pink;
-		border-bottom: 125rem solid @lt-pink;
-		border-left-width: 210rem;
+		border-top-width: 125*@p;
+		border-right: 210*@p solid @lt-pink;
+		border-bottom: 125*@p solid @lt-pink;
+		border-left-width: 210*@p;
 	}
 
 	h1 {
 		position: absolute;
 		margin: 0;
-		top: -230rem;
-		left: 40rem;
+		top: -230*@p;
+		left: 40*@p;
 		color: @purple;
-		font-size: 100rem;
+		font-size: 100*@p;
 		font-weight: @semibold;
 		line-height: 1em;
 
 		em {
 			position: relative;
-			left:-3rem;
+			left:-3*@p;
 			font-weight: @extrabold;
 			display:block;
-			font-size: 170rem;
-			margin-top: 10rem;
+			font-size: 170*@p;
+			margin-top: 10*@p;
 		}
 	}
 	.copy {
 		p {
 			margin: 0;
-			padding: 0 0 28rem;
-			font-size: 18rem;
-			line-height: 28rem;
+			padding: 0 0 28*@p;
+			font-size: 18*@p;
+			line-height: 28*@p;
 		}
 	}
 }
@@ -121,18 +111,18 @@ h1, h2 {
 
 	&:before {
 		.pseudo-box-top();
-		top:320rem;
-		border-top-width: 285rem;
-		border-right: 480rem solid white;
-		border-bottom: 285rem solid white;
-		border-left-width: 480rem;
+		top:320*@p;
+		border-top-width: 285*@p;
+		border-right: 480*@p solid white;
+		border-bottom: 285*@p solid white;
+		border-left-width: 480*@p;
 	}
 
 	img {
 		position:absolute;
 		right:0;
-		top:-60rem;
-		width:450rem;
+		top:-60*@p;
+		width:450*@p;
 	}
 }
 .shoes {
@@ -140,64 +130,64 @@ h1, h2 {
 	z-index: 40;
 	background: @dk-pink;
 	padding-top: 1px;
-	margin-top: 790rem;
+	margin-top: 790*@p;
 
 	&:before {
 		.pseudo-box-top();
-		border-width: 480rem;
+		border-width: 480*@p;
 		border-bottom-color: @dk-pink;
 		border-left-color: @dk-pink;
 	}
 	&:after {
 		.pseudo-box-bottom();
-		border-top: 275rem solid @dk-pink;
-		border-right-width: 480rem;
-		border-bottom-width: 275rem;
-		border-left: 480rem solid @dk-pink;
+		border-top: 275*@p solid @dk-pink;
+		border-right-width: 480*@p;
+		border-bottom-width: 275*@p;
+		border-left: 480*@p solid @dk-pink;
 	}
 
 	h2 {
 		position: absolute;
 		margin: 0;
-		font-size: 350rem;
+		font-size: 350*@p;
 		font-weight: @extrabold;
-		left: -50rem;
-		top: -655rem;
+		left: -50*@p;
+		top: -655*@p;
 	}
 
 	.copy {
 		position: relative;
-		margin: -520rem 0 0 130rem;
-		width: 320rem;
-		transform: translate(0, 210rem);
+		margin: -520*@p 0 0 130*@p;
+		width: 320*@p;
+		transform: translate(0, 210*@p);
 
 		.shape {
 			content:"";
 			display:block;
-			width:170rem;
-			height:330rem;
+			width:170*@p;
+			height:330*@p;
 			float: right;
-			shape-outside: ellipse(170rem 90rem at 100% 210rem);
+			shape-outside: ellipse(170*@p 90*@p at 100% 210*@p);
 		}
 
 		p {
 			margin: 0;
-			padding: 0 0 26rem;
-			font-size: 16rem;
-			line-height: 26rem;
+			padding: 0 0 26*@p;
+			font-size: 16*@p;
+			line-height: 26*@p;
 		}
 
 		img {
 			position: absolute;
-			width: 1010rem;
-			top: -150rem;
-			left: 160rem;
+			width: 1010*@p;
+			top: -150*@p;
+			left: 160*@p;
 		}
 	}
 }
 .runner-3 {
 	position:relative;
-	padding-bottom: 130rem;
+	padding-bottom: 130*@p;
 
 	img {
 		width:100%;
@@ -205,9 +195,9 @@ h1, h2 {
 	.quote {
 		position: absolute;
 		z-index: 60;
-		top: 370rem;
-		left: 130rem;
-		font-size: 19rem;
+		top: 370*@p;
+		left: 130*@p;
+		font-size: 19*@p;
 		text-align: right;
 		.heading-style();
 

--- a/less/demo-la-shoes.less
+++ b/less/demo-la-shoes.less
@@ -71,10 +71,9 @@ h1, h2 {
 
 	&:before {
 		.pseudo-box-top();
-		border-top-width: 125*@p;
-		border-right: 210*@p solid @lt-pink;
-		border-bottom: 125*@p solid @lt-pink;
-		border-left-width: 210*@p;
+		border-right-color: @lt-pink;
+		border-bottom-color: @lt-pink;
+		border-width: 125*@p 210*@p;
 	}
 
 	h1 {
@@ -112,10 +111,9 @@ h1, h2 {
 	&:before {
 		.pseudo-box-top();
 		top:320*@p;
-		border-top-width: 285*@p;
-		border-right: 480*@p solid white;
-		border-bottom: 285*@p solid white;
-		border-left-width: 480*@p;
+		border-right-color: white;
+		border-bottom-color: white;
+		border-width: 285*@p 480*@p;
 	}
 
 	img {
@@ -140,10 +138,9 @@ h1, h2 {
 	}
 	&:after {
 		.pseudo-box-bottom();
-		border-top: 275*@p solid @dk-pink;
-		border-right-width: 480*@p;
-		border-bottom-width: 275*@p;
-		border-left: 480*@p solid @dk-pink;
+		border-top-color: @dk-pink;
+		border-left-color: @dk-pink;
+		border-width: 275*@p 480*@p;
 	}
 
 	h2 {

--- a/less/demo-units.less
+++ b/less/demo-units.less
@@ -1,0 +1,26 @@
+@import "imports/uniform.less";
+
+.pixel-based {
+	font-size: 16px;
+	width: 320px;
+	padding: 20px;
+	border:2px solid black;
+}
+.liquid {
+	font-size: 16px;
+	width: auto;
+	padding: 20px;
+	border:2px solid black;
+}
+.uniform-layout {
+	font-size: 16*@p;
+	width: 320*@p;
+	padding: 20*@p;
+	border:2*@p solid black;
+}
+.uniform-component {
+	font-size: 16rem;
+	width: 320rem;
+	padding: 20rem;
+	border:2rem solid black;
+}

--- a/less/demo-units.less
+++ b/less/demo-units.less
@@ -8,7 +8,7 @@
 }
 .liquid {
 	font-size: 16px;
-	width: auto;
+	width: 33.33333%;
 	padding: 20px;
 	border:2px solid black;
 }

--- a/less/imports/uniform.less
+++ b/less/imports/uniform.less
@@ -3,6 +3,16 @@
 @md: ~"screen and (min-width:960px) and (max-width:1279px)";
 @lg: ~"screen and (min-width:1280px) and (max-width:1919px)";
 @xl: ~"screen and (min-width:1920px)";
+
+@xsp: 100vw/320;
+@smp: 100vw/640;
+@mdp: 100vw/960;
+@lgp: 100vw/1280;
+@xlp: 100vw/1920;
+
+// default
+@p: @mdp;
+
 * {
 	box-sizing: border-box;
 	font-size: 14rem;

--- a/less/imports/uniform.less
+++ b/less/imports/uniform.less
@@ -15,7 +15,6 @@
 
 * {
 	box-sizing: border-box;
-	font-size: 14rem;
 }
 html, body {
 	min-height: 100% !important;
@@ -33,4 +32,5 @@ html {
 }
 body {
 	text-size-adjust: 100%;
+	font-size: 14rem;
 }

--- a/public/css/demo-grid.css
+++ b/public/css/demo-grid.css
@@ -1,6 +1,5 @@
 * {
   box-sizing: border-box;
-  font-size: 14rem;
 }
 html,
 body {
@@ -40,6 +39,7 @@ body {
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
           text-size-adjust: 100%;
+  font-size: 14rem;
 }
 .perimeter {
   min-height: 100%;

--- a/public/css/demo-la-shoes.css
+++ b/public/css/demo-la-shoes.css
@@ -46,14 +46,26 @@ html {
   color: white;
 }
 h1,
-h2 {
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: "proxima-nova-extra-condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   letter-spacing: -0.02em;
+  margin: 0;
 }
 h1 em,
-h2 em {
+h2 em,
+h3 em,
+h4 em,
+h5 em,
+h6 em {
   font-style: normal;
+}
+p {
+  margin: 0;
 }
 .runner-1 img {
   width: 100%;
@@ -83,7 +95,6 @@ h2 em {
 }
 .introduction h1 {
   position: absolute;
-  margin: 0;
   top: -23.95833333vw;
   left: 4.16666667vw;
   color: #7B2F9F;
@@ -100,8 +111,7 @@ h2 em {
   margin-top: 1.04166667vw;
 }
 .introduction .copy p {
-  margin: 0;
-  padding: 0 0 2.91666667vw;
+  padding-bottom: 2.91666667vw;
   font-size: 1.875vw;
   line-height: 2.91666667vw;
 }
@@ -178,7 +188,8 @@ h2 em {
 }
 .shoes .copy {
   position: relative;
-  margin: -54.16666667vw 0 0 13.54166667vw;
+  margin-top: -54.16666667vw;
+  margin-left: 13.54166667vw;
   width: 33.33333333vw;
   transform: translate(0, 21.875vw);
 }
@@ -192,8 +203,7 @@ h2 em {
           shape-outside: ellipse(17.70833333vw 9.375vw at 100% 21.875vw);
 }
 .shoes .copy p {
-  margin: 0;
-  padding: 0 0 2.70833333vw;
+  padding-bottom: 2.70833333vw;
   font-size: 1.66666667vw;
   line-height: 2.70833333vw;
 }

--- a/public/css/demo-la-shoes.css
+++ b/public/css/demo-la-shoes.css
@@ -77,10 +77,9 @@ h2 em {
   top: 0;
   left: 0;
   transform: translate(0, -100%);
-  border-top-width: 13.02083333vw;
-  border-right: 21.875vw solid #e4a3c0;
-  border-bottom: 13.02083333vw solid #e4a3c0;
-  border-left-width: 21.875vw;
+  border-right-color: #e4a3c0;
+  border-bottom-color: #e4a3c0;
+  border-width: 13.02083333vw 21.875vw;
 }
 .introduction h1 {
   position: absolute;
@@ -122,10 +121,9 @@ h2 em {
   left: 0;
   transform: translate(0, -100%);
   top: 33.33333333vw;
-  border-top-width: 29.6875vw;
-  border-right: 50vw solid white;
-  border-bottom: 29.6875vw solid white;
-  border-left-width: 50vw;
+  border-right-color: white;
+  border-bottom-color: white;
+  border-width: 29.6875vw 50vw;
 }
 .runner-2 img {
   position: absolute;
@@ -166,10 +164,9 @@ h2 em {
   bottom: 0;
   left: 0;
   transform: translate(0, 100%);
-  border-top: 28.64583333vw solid #c76591;
-  border-right-width: 50vw;
-  border-bottom-width: 28.64583333vw;
-  border-left: 50vw solid #c76591;
+  border-top-color: #c76591;
+  border-left-color: #c76591;
+  border-width: 28.64583333vw 50vw;
 }
 .shoes h2 {
   position: absolute;

--- a/public/css/demo-la-shoes.css
+++ b/public/css/demo-la-shoes.css
@@ -11,27 +11,27 @@ html {
   width: 100vw;
   overflow-x: hidden;
 }
-@media (max-width:0px) {
+@media screen and (max-width:639px) {
   html {
     font-size: 0.3125vw;
   }
 }
-@media (max-width:0px) {
+@media screen and (min-width:640px) and (max-width:959px) {
   html {
     font-size: 0.15625vw;
   }
 }
-@media all {
+@media screen and (min-width:960px) and (max-width:1279px) {
   html {
     font-size: 0.10416667vw;
   }
 }
-@media (max-width:0px) {
+@media screen and (min-width:1280px) and (max-width:1919px) {
   html {
     font-size: 0.078125vw;
   }
 }
-@media (max-width:0px) {
+@media screen and (min-width:1920px) {
   html {
     font-size: 0.05208333vw;
   }
@@ -61,9 +61,9 @@ h2 em {
 .introduction {
   position: relative;
   z-index: 20;
-  width: 420rem;
-  margin: -675rem 0 0 auto;
-  padding: 10rem 75rem 160rem 45rem;
+  width: 43.75vw;
+  margin: -70.3125vw 0 0 auto;
+  padding: 1.04166667vw 7.8125vw 16.66666667vw 4.6875vw;
   background: #e4a3c0;
 }
 .introduction:before {
@@ -77,34 +77,34 @@ h2 em {
   top: 0;
   left: 0;
   transform: translate(0, -100%);
-  border-top-width: 125rem;
-  border-right: 210rem solid #e4a3c0;
-  border-bottom: 125rem solid #e4a3c0;
-  border-left-width: 210rem;
+  border-top-width: 13.02083333vw;
+  border-right: 21.875vw solid #e4a3c0;
+  border-bottom: 13.02083333vw solid #e4a3c0;
+  border-left-width: 21.875vw;
 }
 .introduction h1 {
   position: absolute;
   margin: 0;
-  top: -230rem;
-  left: 40rem;
+  top: -23.95833333vw;
+  left: 4.16666667vw;
   color: #7B2F9F;
-  font-size: 100rem;
+  font-size: 10.41666667vw;
   font-weight: 600;
   line-height: 1em;
 }
 .introduction h1 em {
   position: relative;
-  left: -3rem;
+  left: -0.3125vw;
   font-weight: 700;
   display: block;
-  font-size: 170rem;
-  margin-top: 10rem;
+  font-size: 17.70833333vw;
+  margin-top: 1.04166667vw;
 }
 .introduction .copy p {
   margin: 0;
-  padding: 0 0 28rem;
-  font-size: 18rem;
-  line-height: 28rem;
+  padding: 0 0 2.91666667vw;
+  font-size: 1.875vw;
+  line-height: 2.91666667vw;
 }
 .runner-2 {
   position: relative;
@@ -121,24 +121,24 @@ h2 em {
   top: 0;
   left: 0;
   transform: translate(0, -100%);
-  top: 320rem;
-  border-top-width: 285rem;
-  border-right: 480rem solid white;
-  border-bottom: 285rem solid white;
-  border-left-width: 480rem;
+  top: 33.33333333vw;
+  border-top-width: 29.6875vw;
+  border-right: 50vw solid white;
+  border-bottom: 29.6875vw solid white;
+  border-left-width: 50vw;
 }
 .runner-2 img {
   position: absolute;
   right: 0;
-  top: -60rem;
-  width: 450rem;
+  top: -6.25vw;
+  width: 46.875vw;
 }
 .shoes {
   position: relative;
   z-index: 40;
   background: #c76591;
   padding-top: 1px;
-  margin-top: 790rem;
+  margin-top: 82.29166667vw;
 }
 .shoes:before {
   content: "";
@@ -151,7 +151,7 @@ h2 em {
   top: 0;
   left: 0;
   transform: translate(0, -100%);
-  border-width: 480rem;
+  border-width: 50vw;
   border-bottom-color: #c76591;
   border-left-color: #c76591;
 }
@@ -166,49 +166,49 @@ h2 em {
   bottom: 0;
   left: 0;
   transform: translate(0, 100%);
-  border-top: 275rem solid #c76591;
-  border-right-width: 480rem;
-  border-bottom-width: 275rem;
-  border-left: 480rem solid #c76591;
+  border-top: 28.64583333vw solid #c76591;
+  border-right-width: 50vw;
+  border-bottom-width: 28.64583333vw;
+  border-left: 50vw solid #c76591;
 }
 .shoes h2 {
   position: absolute;
   margin: 0;
-  font-size: 350rem;
+  font-size: 36.45833333vw;
   font-weight: 700;
-  left: -50rem;
-  top: -655rem;
+  left: -5.20833333vw;
+  top: -68.22916667vw;
 }
 .shoes .copy {
   position: relative;
-  margin: -520rem 0 0 130rem;
-  width: 320rem;
-  transform: translate(0, 210rem);
+  margin: -54.16666667vw 0 0 13.54166667vw;
+  width: 33.33333333vw;
+  transform: translate(0, 21.875vw);
 }
 .shoes .copy .shape {
   content: "";
   display: block;
-  width: 170rem;
-  height: 330rem;
+  width: 17.70833333vw;
+  height: 34.375vw;
   float: right;
-  -webkit-shape-outside: ellipse(170rem 90rem at 100% 210rem);
-          shape-outside: ellipse(170rem 90rem at 100% 210rem);
+  -webkit-shape-outside: ellipse(17.70833333vw 9.375vw at 100% 21.875vw);
+          shape-outside: ellipse(17.70833333vw 9.375vw at 100% 21.875vw);
 }
 .shoes .copy p {
   margin: 0;
-  padding: 0 0 26rem;
-  font-size: 16rem;
-  line-height: 26rem;
+  padding: 0 0 2.70833333vw;
+  font-size: 1.66666667vw;
+  line-height: 2.70833333vw;
 }
 .shoes .copy img {
   position: absolute;
-  width: 1010rem;
-  top: -150rem;
-  left: 160rem;
+  width: 105.20833333vw;
+  top: -15.625vw;
+  left: 16.66666667vw;
 }
 .runner-3 {
   position: relative;
-  padding-bottom: 130rem;
+  padding-bottom: 13.54166667vw;
 }
 .runner-3 img {
   width: 100%;
@@ -216,9 +216,9 @@ h2 em {
 .runner-3 .quote {
   position: absolute;
   z-index: 60;
-  top: 370rem;
-  left: 130rem;
-  font-size: 19rem;
+  top: 38.54166667vw;
+  left: 13.54166667vw;
+  font-size: 1.97916667vw;
   text-align: right;
   font-family: "proxima-nova-extra-condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-transform: uppercase;

--- a/public/css/demo-la-shoes.css
+++ b/public/css/demo-la-shoes.css
@@ -1,6 +1,5 @@
 * {
   box-sizing: border-box;
-  font-size: 14rem;
 }
 html,
 body {
@@ -40,6 +39,7 @@ body {
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
           text-size-adjust: 100%;
+  font-size: 14rem;
 }
 html {
   font-family: "proxima-nova", "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/public/css/demo-template.css
+++ b/public/css/demo-template.css
@@ -1,6 +1,5 @@
 * {
   box-sizing: border-box;
-  font-size: 14rem;
 }
 html,
 body {
@@ -40,4 +39,5 @@ body {
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
           text-size-adjust: 100%;
+  font-size: 14rem;
 }

--- a/public/css/demo-units.css
+++ b/public/css/demo-units.css
@@ -1,6 +1,5 @@
 * {
   box-sizing: border-box;
-  font-size: 14rem;
 }
 html,
 body {
@@ -40,6 +39,7 @@ body {
   -webkit-text-size-adjust: 100%;
       -ms-text-size-adjust: 100%;
           text-size-adjust: 100%;
+  font-size: 14rem;
 }
 .pixel-based {
   font-size: 16px;
@@ -49,7 +49,7 @@ body {
 }
 .liquid {
   font-size: 16px;
-  width: auto;
+  width: 33.33333%;
   padding: 20px;
   border: 2px solid black;
 }

--- a/public/css/demo-units.css
+++ b/public/css/demo-units.css
@@ -1,0 +1,67 @@
+* {
+  box-sizing: border-box;
+  font-size: 14rem;
+}
+html,
+body {
+  min-height: 100% !important;
+  height: 100%;
+}
+html {
+  width: 100vw;
+  overflow-x: hidden;
+}
+@media screen and (max-width:639px) {
+  html {
+    font-size: 0.3125vw;
+  }
+}
+@media screen and (min-width:640px) and (max-width:959px) {
+  html {
+    font-size: 0.15625vw;
+  }
+}
+@media screen and (min-width:960px) and (max-width:1279px) {
+  html {
+    font-size: 0.10416667vw;
+  }
+}
+@media screen and (min-width:1280px) and (max-width:1919px) {
+  html {
+    font-size: 0.078125vw;
+  }
+}
+@media screen and (min-width:1920px) {
+  html {
+    font-size: 0.05208333vw;
+  }
+}
+body {
+  -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+          text-size-adjust: 100%;
+}
+.pixel-based {
+  font-size: 16px;
+  width: 320px;
+  padding: 20px;
+  border: 2px solid black;
+}
+.liquid {
+  font-size: 16px;
+  width: auto;
+  padding: 20px;
+  border: 2px solid black;
+}
+.uniform-layout {
+  font-size: 1.66666667vw;
+  width: 33.33333333vw;
+  padding: 2.08333333vw;
+  border: 0.20833333vw solid black;
+}
+.uniform-component {
+  font-size: 16rem;
+  width: 320rem;
+  padding: 20rem;
+  border: 2rem solid black;
+}

--- a/public/demo-units.html
+++ b/public/demo-units.html
@@ -12,10 +12,13 @@
 
 		<div class="perimeter">
 
-			<div class="pixel-based">This block doesn't flex at all. This is how we used to design in the early 2000s. It's ok if all you care about is desktop.</div>
-			<div class="liquid">This block is liquid. This is how we've had to design for the past decade. It is evil and we should stop.</div>
-			<div class="uniform-layout">This block is always the same size relative to the screen. This is great for making graphical layouts that are the same on every device.</div>
-			<div class="uniform-component">This block is internally consistent on each screen size. This is great for re-usable, text-rich components that are different sizes on different devices, but always about the same physical size.</div>
+			<div class="pixel-based"><b>Pixels.</b> This block doesn't flex at all. This is how we used to design in the early 2000s. It's ok if you only really care about one screen size.</div>
+
+			<div class="liquid"><b>Liquid.</b> This block is stretches and squishes unpredictably based on the available space, because the contents don't flex. This is how we've had to design for the past decade. It is evil and we should stop.</div>
+
+			<div class="uniform-layout"><b>Uniform layout.</b> This block is always the same size relative to the screen. This is great for making graphical layouts that are the same on every device.</div>
+
+			<div class="uniform-component"><b>Uniform component.</b> This block is internally consistent on each screen size. This is great for re-usable, text-rich components that are different sizes on different devices, but always about the same physical size.</div>
 
 		</div>
 

--- a/public/demo-units.html
+++ b/public/demo-units.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>Uniform</title>
+		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
+		<link rel="stylesheet" href="css/demo-units.css">
+	</head>
+	<body>
+
+		<div class="perimeter">
+
+			<div class="pixel-based">This block doesn't flex at all. This is how we used to design in the early 2000s. It's ok if all you care about is desktop.</div>
+			<div class="liquid">This block is liquid. This is how we've had to design for the past decade. It is evil and we should stop.</div>
+			<div class="uniform-layout">This block is always the same size relative to the screen. This is great for making graphical layouts that are the same on every device.</div>
+			<div class="uniform-component">This block is internally consistent on each screen size. This is great for re-usable, text-rich components that are different sizes on different devices, but always about the same physical size.</div>
+
+		</div>
+
+	</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,9 @@
 		<div style="padding:20px;">
 			<h1>Uniform demos</h1>
 			<ul>
-				<li><a href="demo-template.html">Template (blank, unstyled)</a></li>
-				<li><a href="demo-grid.html">Grid</a></li>
-				<li><a href="demo-la-shoes.html">Shoes</a></li>
-				<li>...</li>
+				<li><a href="demo-la-shoes.html"><b>Shoes:</b> Kevin's design, Linc's code</a></li>
+				<li><a href="demo-grid.html"><b>Grid:</b> A simple responsive grid with no media queries.</a></li>
+				<li><a href="demo-units.html"><b>Units:</b> A demonstration of the old and new methods.</a></li>
 			</ul>
 		</div>
 	</body>


### PR DESCRIPTION
This change supplies the user with a set of variables that each represent 1 pixel at their breakpoint. Each variable name is the breakpoint size suffixed with "p": `@xsp`, `@smp`, `@mdp`, `@lgp` and `@xlp`.

For example, an element assigned a width of `32 * @smp` will be 32 pixels wide on a small (320px) screen, or 10%. The element will then always be 10% of the screen width at any size. This way, the user does not have to calculate the `vw` units or set `rem` values at each breakpoint.
